### PR TITLE
Avoid indexError

### DIFF
--- a/hashtable/linear_probing.py
+++ b/hashtable/linear_probing.py
@@ -31,11 +31,11 @@ class LinearProbingTable:
             return value
         index += 1 % len(self.table)
 
-        while index != start_index:
+        while index != start_index and self.table[index]:
             current_key, value = self.table[index]
             if current_key == key:
                 return value
-            index += 1 % len(self.table)
+            index = (index + 1) % len(self.table)
 
         # Return default if we don't find the key.
         return default


### PR DESCRIPTION
There's a couple of errors in the linear probing solution I found, you can compare with [my solution](https://github.com/CheezItMan/hash-table-exercise/blob/main/hashtable/linear_probing.py)