### PR TITLE
Fix bug in linear probing get.

### DIFF
--- a/hashtable/linear_probing.py
+++ b/hashtable/linear_probing.py
@@ -29,7 +29,7 @@ class LinearProbingTable:
         current_key, value = self.table[index]
         if current_key == key:
             return value
-        index += 1 % len(self.table)
+        index = (index + 1) % len(self.table)
 
         while index != start_index and self.table[index]:
             current_key, value = self.table[index]


### PR DESCRIPTION
Fixes non-deterministic test failure when the hash value of the key to get was at the end of the list.